### PR TITLE
fixing favicon background color and icon path

### DIFF
--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -1,6 +1,7 @@
 const commonConfig = require('./webpack.config.common');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const FaviconsWebpackPlugin = require('favicons-webpack-plugin');
+const path = require('path');
 const webpackMerge = require('webpack-merge');
 
 module.exports = webpackMerge(commonConfig, {
@@ -13,13 +14,12 @@ module.exports = webpackMerge(commonConfig, {
 
   plugins: [
     new FaviconsWebpackPlugin({
-      logo: './favicon.png',
+      logo: path.join(__dirname, 'src', 'favicon.png'),
       emitStats: true,
-      prefix: '/',
       statsFilename: 'icons/stats.json',
       inject: true,
       title: 'Contributary',
-      background: '#466628',
+      background: '#efefef',
       icons: {
         android: true,
         appleIcon: false,


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #22 

## Summary of Changes
1. Set favicons background color to white
1. Don't set prefix for favicons, which omits the '/', which seems to gets turned into an entity by `S3WebpacbPlugin`, and doesn't need to be `/` for any particular reason, that I can see.

<img width="135" alt="screen shot 2018-11-17 at 6 11 43 pm" src="https://user-images.githubusercontent.com/895923/48666671-4e07e600-ea94-11e8-83dc-9baf1fa80b89.png">

<img width="1566" alt="screen shot 2018-11-17 at 6 12 25 pm" src="https://user-images.githubusercontent.com/895923/48666678-5c560200-ea94-11e8-8ac2-c1230893a1b2.png">