### PR TITLE
add alt for image

### DIFF
--- a/src/components/header/header.js
+++ b/src/components/header/header.js
@@ -13,7 +13,7 @@ class HeaderComponent extends LitElement {
       <header>
 
         <h1>Welcome to Contributary!</h1>
-        <img src="${logo}"/>
+        <img src="${logo}" alt="Contributary logo"/>
         <h3><i>Helping connect open source with the open source community.</i></h3>
         
       </header>


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
From Lighthouse
<img width="926" alt="screen shot 2018-11-17 at 7 04 46 pm" src="https://user-images.githubusercontent.com/895923/48667085-a3e08c00-ea9c-11e8-9f70-9d49fd1d2923.png">


## Summary of Changes
1. Added an `alt` attribute to the header image
<img width="878" alt="screen shot 2018-11-17 at 7 12 28 pm" src="https://user-images.githubusercontent.com/895923/48667093-d5f1ee00-ea9c-11e8-95bc-f0fcf0eb3d18.png">