### PR TITLE
icons and manifest output and path consistency

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -11,7 +11,7 @@
     <meta name='apple-mobile-web-app-capable' content='yes'/>
     <meta name='apple-mobile-web-app-status-bar-style' content='black'/>
     <meta name="description" content="A project for helping connect open source with the open source community."/>
-    <link rel="manifest" href="/manifest.json">
+    <link rel="manifest" href="/icons/manifest.json">
 
     <meta property="og:title" content="Contributary" />
     <meta property="og:type" content="website" />

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -19,6 +19,7 @@ module.exports = webpackMerge(commonConfig, {
       statsFilename: 'icons/stats.json',
       inject: true,
       title: 'Contributary',
+      prefix: 'icons/',
       background: '#efefef',
       icons: {
         android: true,


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves a #38, which introduced a regression into loading app manifest

## Summary of Changes
1. Make output paths consistent between **webpack** and _index.html_