### PR TITLE
add a message when no repositories or issues are returned

### DIFF
--- a/src/pages/home/home.js
+++ b/src/pages/home/home.js
@@ -91,6 +91,8 @@ class HomePageComponent extends LitElement {
         this.projectOptions = [
           ...newProjectOptions
         ];
+        this.repositoryOptions = null;
+        this.issues = null;
       });
     }
   }
@@ -132,6 +134,7 @@ class HomePageComponent extends LitElement {
     this.repositoryOptions = [
       ...newRepositoryOptions
     ];
+    this.issues = null;
   }
 
   // step 3 - user selects a repository to see available issues
@@ -193,7 +196,7 @@ class HomePageComponent extends LitElement {
         : ''
       }
 
-      ${repositoryOptions
+      ${repositoryOptions && repositoryOptions.length
         ? html`
             <div class="selection-wrapper">
               <h2>Step 3: Select a Repository</h2>
@@ -204,10 +207,16 @@ class HomePageComponent extends LitElement {
               ></cc-dropdown>
             </div>
           `
-        : ''
+        : repositoryOptions && !repositoryOptions.length
+          ? html`
+          <div class="selection-wrapper">
+            <h3>No repositories found for the selected project</h3>
+          </div>
+        `
+          : ''
       }
 
-      ${issues
+      ${issues && issues.length
         ? html`
             <div class="selection-wrapper">
               <h2>Step 4: Find an issue and help out!</h2>
@@ -220,7 +229,13 @@ class HomePageComponent extends LitElement {
               </cc-issues-list>
             </div>
           `
-        : ''
+        : issues && !issues.length
+          ? html`
+            <div class="selection-wrapper">
+              <h3>No issues found for the selected repository</h3>
+            </div>
+          `
+          : ''
       }
 
     </div>

--- a/src/services/github-service.js
+++ b/src/services/github-service.js
@@ -4,22 +4,24 @@ export class GitHubService {
     this.baseUrl = '/api/github';
   }
 
-  getRepositoriesForProject(projectName, repoType) {
-    const query = `projectName=${projectName}&repoType=${repoType}`;
+  getRepositoriesForProject(projectName, repositoryType) {
+    const query = `projectName=${projectName}&repoType=${repositoryType}`;
 
     return fetch(`${this.baseUrl}/repositories?${query}`)
       .then((resp) => { return resp.json(); })
       .then((response) => {
+        const repositories = [];
+
         if (response && response.length) {
-          return response.map((repo) => {
-            return {
-              id: repo.id,
-              name: repo.name
-            };
+          response.forEach((repository) => {
+            repositories.push({
+              id: repository.id,
+              name: repository.name
+            });
           });
-        } else {
-          return [];
         }
+
+        return repositories;
       });
   }
 

--- a/src/services/github-service.js
+++ b/src/services/github-service.js
@@ -10,12 +10,16 @@ export class GitHubService {
     return fetch(`${this.baseUrl}/repositories?${query}`)
       .then((resp) => { return resp.json(); })
       .then((response) => {
-        return response.map((repo) => {
-          return {
-            id: repo.id,
-            name: repo.name
-          };
-        });
+        if (response && response.length) {
+          return response.map((repo) => {
+            return {
+              id: repo.id,
+              name: repo.name
+            };
+          });
+        } else {
+          return [];
+        }
       });
   }
 


### PR DESCRIPTION
## Related Issue
Resolves #18 

## Summary of Changes
1. [x] Display a message when fetched list of Repositories is empty
1. [x] Display a message when fetched list of Issues is empty

## Notes
1. This PR differentiates between three render states for the list of Repos and Issues. It assumes 1) null indicates a pre-fetch state (we still need to get items for the list), 2) an  empty array indicates "no results", and 3) an array with length contains the items.
=> should we implement another convention? 
2. I am not sure of the protocol for naming branches, etc., so let me have it so I can learn. :)