### PR TITLE
dont escape psueduo selector content

### DIFF
--- a/src/components/dropdown/dropdown.css
+++ b/src/components/dropdown/dropdown.css
@@ -85,7 +85,7 @@
     }
 
     &::after {
-      content: \"\";
+      content: "";
       position: absolute;
       right: 0.8em;
       top: 0.9em;


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love contributions and appreciate any help you can offer!
-->

## Related Issue
resolves #95

## Summary of Changes
1. Don't escape content for the pseudo selector, which Chrome didn't seem to like
![Screen Shot 2021-09-27 at 11 14 58 AM](https://user-images.githubusercontent.com/895923/134937941-fc828035-7d40-4e52-a273-4b8d22094564.png)